### PR TITLE
Incorrect CMakeList.txt path?

### DIFF
--- a/heapsapp/build.gradle
+++ b/heapsapp/build.gradle
@@ -22,7 +22,7 @@ android {
     }
     externalNativeBuild {
         cmake {
-            path '../../CMakeLists.txt'
+            path 'CMakeLists.txt'
         }
     }
 }


### PR DESCRIPTION
At first build attempt, I got the following error:
Gradle project cmake.path is C:\Users\jonas\Dropbox\_dev\heaps\CMakeLists.txt but that file doesn't exist

After changing the path from '../../CmakeList.txt' to 'CMakeList.txt', the project builds without errors.